### PR TITLE
fix issue with kernel compilation

### DIFF
--- a/Changelog-mfakto.txt
+++ b/Changelog-mfakto.txt
@@ -1,4 +1,6 @@
 version 0.15 (...)
+- fixed issue: kernel compilation does not work correctly if a device number
+  greater than 1 is specified
 - added detection for more devices
 - fixed an issue where verbosity was not passed to valid_assignment()
 - removed dependency on AMD APP SDK as it has been discontinued

--- a/README.txt
+++ b/README.txt
@@ -199,24 +199,25 @@ run 'mfakto -st' each time you:
 # 2.1 Supported GPUs #
 ######################
 
-mfakto should run on most modern AMD GPUs:
-- supports APUs
-- the Radeon HD 4000 series, FireStream 9250 and FireStream 9270 do not support
-  atomic operations*
-- kernel compilation fails for the Radeon HD 2000 / 3000 series and the
-  FireStream 9170 as these devices do not support OpenCL
+AMD:
+- all devices that support OpenCL 1.1 or later
+- all APUs
+- OpenCL 1.0 devices, such as the FireStream 9250 / 9270 and Radeon HD 4000
+  series, can also run mfakto but do not support atomic operations*
+- not supported: Radeon HD 2000 / 3000 series and FireStream 9170 (as kernel
+  compilation fails)
 
 Other:
 - Intel HD Graphics 4000 and later. Self-tests currently fail on macOS.
-- can be configured to run on x86 CPUs using 'mfakto -d c'
-- Nvidia devices are currently not supported
+- OpenCL-enabled CPUs via the '-d c' option
+- not currently supported: Nvidia devices
 
-* without atomics, multiple factors found in the same block are not processed
-correctly. Tests have shown that mfakto will report only one factor. It may
-even return an incorrect factor due to a mix of bytes from multiple factors.
-PrimeNet will automatically check factors and reject any incorrect ones. In
-this case, please rerun the exponent and bit level on the CPU by using either
-'mfakto -d c' or Prime95 / mprime.
+* without atomics, mfakto does not correctly process multiple factors found in
+the same block / grid. Tests have shown that it will report only one factor. It
+may even return a scrambled factor due to a mix of bytes from multiple factors.
+PrimeNet will automatically reject factors that do not divide a Mersenne
+number. If this happens, rerun the exponent and bit level on the CPU with
+either the '-d c' option or Prime95 / mprime.
 
 #############
 # 2.2 Linux #
@@ -335,16 +336,16 @@ Submitting results:
 # 4 Known issues #
 ##################
 
-- On some devices, mfakto may be very slow at full load. It will warn about the
-  issue during startup.
+- On some devices, mfakto may be very slow at full GPU load. It will warn about
+  this during startup.
   This is due to fewer registers being available to the kernels.
   Set VectorSize=2 in mfakto.ini and restart mfakto to resolve this.
 
-- The user interface is not hardened against malformed input. There are some
-  checks but if you really try you should be able to screw it up.
+- The user interface has not been extensively tested against invalid inputs.
+  Although there are some checks, they are not foolproof by any means.
 
-- Your GUI may lag while running mfakto. In severe cases, Windows may decide
-  the driver is faulty and reboot or even throw a BSoD.
+- Your GUI may lag while running mfakto. In severe cases, Windows may restart
+  the driver or even throw a BSoD.
   Try lowering GridSize or NumStreams in your mfakto.ini file. Smaller grids
   should have better responsiveness at a slight performance loss. To prevent
   graphics driver crashes on Windows, another option is to increase the GPU
@@ -357,8 +358,8 @@ Submitting results:
   This happens on Linux when there is no X server. It can also happen on
   Windows when the GPU is not the primary display adapter. Try running mfakto
   on the main display rather than remotely. If that fails, then your graphics
-  driver may be too old. It's also possible that the first device is not an AMD
-  GPU. In this case, use the -d switch to specify a different device number.
+  driver may be too old. It's also possible that the first GPU is not an AMD
+  one. In this case, use the -d switch to specify a different device number.
   You can run clinfo to get a list of devices.
 
 ##################

--- a/README.txt
+++ b/README.txt
@@ -335,8 +335,8 @@ Submitting results:
 # 4 Known issues #
 ##################
 
-- On HD77xx, 78xx, 79xx and R series, mfakto may be very slow at
-  99% GPU load. It will warn about the issue during startup.
+- On some devices, mfakto may be very slow at full load. It will warn about the
+  issue during startup.
   This is due to fewer registers being available to the kernels.
   Set VectorSize=2 in mfakto.ini and restart mfakto to resolve this.
 

--- a/src/mfakto.cpp
+++ b/src/mfakto.cpp
@@ -703,7 +703,7 @@ void set_gpu_type()
     printf("  maximum threads per block %d\n", (int)deviceinfo.maxThreadsPerBlock);
     printf("  maximum threads per grid  %d\n", (int)deviceinfo.maxThreadsPerGrid);
     printf("  number of multiprocessors %d (%d compute elements)\n", deviceinfo.units, deviceinfo.units * gpu_types[mystuff.gpu_type].CE_per_multiprocessor);
-    printf("  clock rate                %dMHz\n", deviceinfo.max_clock);
+    printf("  clock rate                %d MHz\n", deviceinfo.max_clock);
 
     printf("\nAutomatic parameters\n");
 

--- a/src/mfakto.cpp
+++ b/src/mfakto.cpp
@@ -991,10 +991,12 @@ int load_kernels(cl_int *devnumber)
       std::cerr << "Failed to allocate host memory.(binaries, " << (sizeof(char *) * numDevices) << " bytes)\n";
       break;
     }
+    int active_device = 0;
     for(i = 0; i < numDevices; i++)
     {
       if(binarySizes[i] != 0)
       {
+        active_device = i;
         binaries[i] = (char *)malloc( sizeof(char) * binarySizes[i]);
         if(!binaries[i])
         {
@@ -1024,11 +1026,11 @@ int load_kernels(cl_int *devnumber)
       std::cout << "Warning: Dumping only the first of " << numDevices <<
         " binary formats - if loading the binary file " << mystuff.binfile <<  " fails, delete it and specify the -d <n> option for mfakto.\n";
     }
-    if(binarySizes[0] != 0)
+    if(binarySizes[active_device] != 0)
     {
         char deviceName[1024];
         status = clGetDeviceInfo(
-                     devices[0],
+                     devices[active_device],
                      CL_DEVICE_NAME,
                      sizeof(deviceName),
                      deviceName,
@@ -1045,7 +1047,7 @@ int load_kernels(cl_int *devnumber)
           char header[180];
           sprintf(header, "Compile options: %s\n", program_options);
           f.write(header, strlen(header));
-          f.write(binaries[0], binarySizes[0]);
+          f.write(binaries[active_device], binarySizes[active_device]);
           f.close();
           if (mystuff.verbosity > 1) printf("Wrote binary kernel for \"%s\" to \"%s\".\n", deviceName, mystuff.binfile);
         }

--- a/src/mfakto.cpp
+++ b/src/mfakto.cpp
@@ -1023,8 +1023,9 @@ int load_kernels(cl_int *devnumber)
     /* dump out each binary into its own separate file. */
     if (1 < numDevices)
     {
-      std::cout << "Warning: Dumping only the first of " << numDevices <<
-        " binary formats - if loading the binary file " << mystuff.binfile <<  " fails, delete it and specify the -d <n> option for mfakto.\n";
+        std::cout << "Info: Dumping only 1 of " << numDevices << " binary formats.\n";
+        std::cout << "      If the kernel file " << mystuff.binfile <<  " fails to load, delete it and\n";
+        std::cout << "      restart mfakto with the -d <n> option.\n";
     }
     if(binarySizes[active_device] != 0)
     {
@@ -1053,15 +1054,13 @@ int load_kernels(cl_int *devnumber)
         }
         else
         {
-          std::cerr << "Failed to open binary file " << mystuff.binfile << "to save kernel.\n";
+          std::cerr << "Failed to open binary file " << mystuff.binfile << " to save kernel.\n";
         }
     }
     else
     {
-        printf(
-            "binary kernel(%s) : %s\n",
-            mystuff.binfile,
-            "Skipping as there is no binary data to write.\n");
+        printf("Did not create binary kernel: %s\n", mystuff.binfile);
+        printf("Skipping as there is no binary data to write.\n");
         remove(mystuff.binfile);
     }
     break;

--- a/src/mfakto.ini
+++ b/src/mfakto.ini
@@ -98,12 +98,13 @@ NumStreams=3
 
 # Sets the number of factor candidates a single GPU thread will test in
 # parallel. A larger value increases the execution unit utilization but
-# requires more registers. If mfakto needs more storage than available in
-# registers, then the slower scratchpad memory will be used. On most hardware,
-# this happens when the vector size is 8 and above.
-# On a Radeon HD 6870, VectorSize=8 is the fastest for the barrett_92 and
-# and barrett24 kernels. It is about 0.8% faster than VectorSize=4 in the
-# former case. For all other kernels, VectorSize=4 gives the best performance.
+# requires more registers. If mfakto needs more storage than available, then
+# the slower scratchpad memory will be used. On most hardware, this happens at
+# a vector size of 8 or above.
+# Testing on a Radeon HD 6870 has shown that VectorSize=8 is the fastest for
+# the barrett92 (about 0.8% faster than VectorSize=4 in this case) and
+# barrett24 kernels. For everything else, a vector size of 4 gives the best
+# performance.
 # It is recommended to use VectorSize=2 on the Radeon HD 7700 - 7900 series as
 # there are less registers available.
 #
@@ -416,9 +417,8 @@ UseBinfile=mfakto_Kernels.elf
 
 ##### Options for --perftest #####
 
-# TestSieveSizes: the sieve sizes used to test the CPU sieve. Each value is a
-# multiplier of the internal sieve chunk size of 13 * 17 * 19 * 23 bits, or
-# around 12 kB.
+# TestSieveSizes: used to test the CPU sieve. Values are multipliers of ~12 kB,
+# the internal sieve chunk size of 13 * 17 * 19 * 23 bits.
 #
 # Allowed values:
 # Comma-separated list without spaces.

--- a/src/mfakto.ini
+++ b/src/mfakto.ini
@@ -63,17 +63,18 @@ SievePrimesMin=5000
 SievePrimesMax=200000
 
 
-# Define the block size of the sieve in kiB. For small SievePrimes values, the
-# size of the L1 cache is a good choice, starting at SievePrimes ~ 100000,
-# bigger values are more efficient. Use mfakto --perftest to test your CPU
-# for the best values. Intel CPUs often have 32 kiB L1 cache, AMD 64 kiB,
-# Bulldozer 16 kiB. On Bulldozer, however, it makes more sense to use the
-# L2 cache size, 256 kiB.
+# Defines the sieve block size in kiB. Only used if SIEVE_SIZE_LIMIT was not
+# set during compilation.
+# For small SievePrimes values starting at ~100000, the L1 cache size is a good
+# choice. Intel CPUs usually have 32 kiB while most AMD processors have 64 kiB.
+# However, the L1 cache is only 16 kiB on Bulldozer, so it makes more sense to
+# use the L2 cache size, 256 kiB.
 #
-# Only used if SIEVE_SIZE_LIMIT was not set during compilation.
+# Larger values are generally better. You can use the --perftest option to find
+# the best values.
 #
 # Minimum: SieveSizeLimit=12
-# Maximum: SieveSizeLimit=2000   (not enforced, but maximum useful value)
+# Maximum: SieveSizeLimit=2000 (not enforced, but maximum useful value)
 #
 # Default: SieveSizeLimit=64
 
@@ -95,15 +96,16 @@ SieveSizeLimit=64
 NumStreams=3
 
 
-# Set the number of factor candidates that a single GPU-thread will work
-# on in parallel. This increases the execution unit utilization but
-# requires more registers. When more space is needed than available in
-# registers, then (slow) scratchpad memory (global memory) will be used.
-# On most hardware this will start happening at vector size 8.
-# On a HD6870, a vector size of 4 is fastest except for the barrett_92
-# kernel which runs about 0.8% faster with vector size 8.
-# The barrett24 kernel is fastest with vector size 8.
-# On GCN (HD77xx-HD79xx), use VectorSize=2 as there are less registers available.
+# Sets the number of factor candidates a single GPU thread will test in
+# parallel. A larger value increases the execution unit utilization but
+# requires more registers. If mfakto needs more storage than available in
+# registers, then the slower scratchpad memory will be used. On most hardware,
+# this happens when the vector size is 8 and above.
+# On a Radeon HD 6870, VectorSize=8 is the fastest for the barrett_92 and
+# and barrett24 kernels. It is about 0.8% faster than VectorSize=4 in the
+# former case. For all other kernels, VectorSize=4 gives the best performance.
+# It is recommended to use VectorSize=2 on the Radeon HD 7700 - 7900 series as
+# there are less registers available.
 #
 # Allowed values: 1, 2, 4, 8, 16
 #
@@ -239,7 +241,7 @@ TimeStampInResults=1
 #  %l - starting bit level           "%2d"
 #  %u - ending bit level             "%2d"
 #
-# ProgressHeader specifies a fixed string that is displayed as a header.
+# ProgressHeader specifies a fixed string to be displayed as a header.
 
 # mfaktc 0.20 format (default)
 ProgressHeader=Date    Time | class   Pct |   time     ETA | GHz-d/day    Sieve     Wait
@@ -372,7 +374,7 @@ GPUSieveProcessSize=24
 # MoreClasses defines whether 420 (2*2*3*5*7) or 4620 (2*2*3*5*7*11) classes of
 # factor candidates should be used. 4620 normally gives better results, but for
 # very small classes, 420 reduces the class initialization overhead enough to
-# provide an overall performance increase.
+# provide overall improvements.
 # Used only when SieveOnGPU=1 as the CPU sieve always uses 4620 classes.
 #
 # Possible values:
@@ -414,8 +416,8 @@ UseBinfile=mfakto_Kernels.elf
 
 ##### Options for --perftest #####
 
-# TestSieveSizes: the sieve sizes to be tested with the CPU sieve. Each value
-# is a multiplier of the internal sieve chunk size of 13 * 17 * 19 * 23 bits =
+# TestSieveSizes: the sieve sizes used to test the CPU sieve. Each value is a
+# multiplier of the internal sieve chunk size of 13 * 17 * 19 * 23 bits, or
 # around 12 kB.
 #
 # Allowed values:
@@ -427,12 +429,12 @@ UseBinfile=mfakto_Kernels.elf
 TestSieveSizes=1,2,3,4,5,6,7,8,9,10,11,13,16,19,20,21,22,25,30,36,43,50,58,67,77,88,100,120,170
 
 
-# TestSievePrimes: the SievePrimes values to be tested for each of the above
-# sieve sizes. Used to test both the CPU and GPU sieves.
+# TestSievePrimes: the SievePrimes values to be tested for the above sieve
+# sizes. Used for both the CPU and GPU sieve tests.
 #
 # Allowed values:
 # Comma-separated list without spaces.
-# Can have up 30 values in the 256 – 1000000 range.
+# Can have up to 30 values in the 256 – 1000000 range.
 #
 # Some examples:
 # 30000,36081,43393,52189,62766,75488,90788,109190,131321,157937,189949,228448,274751,330439,397413,477963,574838,691348,831474,1000000
@@ -445,19 +447,22 @@ TestSieveSizes=1,2,3,4,5,6,7,8,9,10,11,13,16,19,20,21,22,25,30,36,43,50,58,67,77
 
 TestSievePrimes=54,396,611,945,1460,2257,3487,5389,8328,12871,19890,30738,47503,73411,113449,175323,270944,418716,647083,1075766
 
-# TestGPUSieveSizes: the sieve sizes to be tested with the CPU sieve, in Mib.
-# Uses the TestSievePrimes values as defined above.
+# TestGPUSieveSizes: the sieve sizes used to test the GPU sieve, in Mib.
+# Uses the TestSievePrimes values defined above.
 #
-# Possible values:
-# Comma-separated list with no spaces.
+# Allowed values:
+# Comma-separated list without spaces.
 # Can have up to 30 values in the 4 – 128 range.
 #
 # no default: skipped if empty
 
 TestGPUSieveSizes=4,5,6,7,8,9,10,12,16,20,24,36,48,96,101,102,103,104,105,106,120,121,123,124,125,126,127,128
 
-# TestExponents: a list of exponents to use when testing the TF kernels. Both
-# the GPU and CPU sieving kernels use the same values.
+# TestExponents: exponents to use when testing the TF kernels. Used by both the
+# GPU and CPU sieving kernels.
+#
+# Allowed values:
+# Comma-separated list without spaces. Exponents are limited to 32 bits.
 
 TestExponents=2000093,39000037,66362159,74000077,78000071,332900047,999900079,2001862367,4201971233
 

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -451,7 +451,7 @@ int read_config(mystuff_t *mystuff)
         i = GPU_SIEVE_PROCESS_SIZE_MIN;
       }
     }
-    if(mystuff->verbosity >= 1)printf("  GPUSieveProcessSize       %dKi bits\n",i);
+    if(mystuff->verbosity >= 1)printf("  GPUSieveProcessSize       %d Kib\n",i);
     mystuff->gpu_sieve_processing_size = i * 1024;
 
 /*****************************************************************************/
@@ -482,7 +482,7 @@ int read_config(mystuff_t *mystuff)
         printf("adjusting GPUSieveSize to %dM\n", i);
       }
     }
-    if(mystuff->verbosity >= 1)printf("  GPUSieveSize              %dMi bits\n",i);
+    if(mystuff->verbosity >= 1)printf("  GPUSieveSize              %d Mib\n",i);
     mystuff->gpu_sieve_size = i * 1024 * 1024;
 
     /*****************************************************************************/
@@ -565,7 +565,7 @@ int read_config(mystuff_t *mystuff)
       printf("WARNING: Minimum value for CheckpointDelay is 0s\n");
       i = 0;
     }
-    if(mystuff->verbosity >= 1)printf("  CheckpointDelay           %ds\n", i);
+    if(mystuff->verbosity >= 1)printf("  CheckpointDelay           %d s\n", i);
     mystuff->checkpointdelay = i;
   }
 


### PR DESCRIPTION
This fixes an issue in which mfakto would not keep the kernel file after compilation if the -d option is used to specify a device number greater than 1. In the original code, mfakto would always search for the binary in the first slot regardless of the device number specified. It should now search though all the slots until it finds a valid one.

I also updated more of the documentation.