### PR TITLE
Compile fix 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ x64/
 *.ckp.bu
 results.txt
 worktodo.txt
+
+# other
+.DS_Store

--- a/Changelog-mfakto.txt
+++ b/Changelog-mfakto.txt
@@ -2,7 +2,6 @@ version 0.15 (...)
 - recognition of more, newer GPUs
 - fixed issue: kernel compilation does not work correctly if a device number
   greater than 1 is specified
-- added detection for more devices
 - fixed an issue where verbosity was not passed to valid_assignment()
 - removed dependency on AMD APP SDK as it has been discontinued
 - updated Windows build instructions and fixed some errors

--- a/README.txt
+++ b/README.txt
@@ -239,8 +239,9 @@ Other:
 the same block / grid. It may report only one factor or even an incorrect one,
 the latter due to scrambled data from multiple factors. PrimeNet automatically
 rejects factors that do not divide a Mersenne number. If this happens, run the
-exponent and bit level again on the CPU or another device. You can tell mfakto
-to run on the CPU using the '-d c' option or use Prime95 instead.
+exponent and bit level again on the CPU or another device. You can run mfakto
+on the CPU using the '-d c' option or use Prime95 instead. Lowering GridSize in
+mfakto.ini can also reduce the chance of error.
 
 #############
 # 2.2 Linux #
@@ -378,8 +379,8 @@ Submitting results:
 - Your GUI may lag while running mfakto. On some Windows systems, the OS may
   restart the driver or even throw a BSoD in severe cases.
   Try lowering GridSize or NumStreams in your mfakto.ini file. Smaller grids
-  should have better responsiveness at a slight performance loss. For Windows
-  users, another option is to increase the GPU processing time:
+  should have better responsiveness at a slight performance loss. Another
+  option for Windows users is to increase the GPU processing time:
   https://support.microsoft.com/en-us/help/2665946
 
 - SievePrimesAdjust is not always optimal. Experiment to find the best
@@ -393,13 +394,14 @@ Submitting results:
   AMD GPU. In this case, use the -d switch to specify a different device
   number. You can run 'clinfo' to get a list of devices.
 
-- on devices that do not support atomic oprations, mfakto may not correctly
-  process multiple factors found in the same block / grid. It may report only
-  one factor or even an incorrect one, the latter due to scrambled data from
+- on devices that do not support atomic operations, mfakto may not correctly
+  process multiple factors found in the same class. It may report only one
+  factor or even an incorrect one, the latter due to scrambled data from
   multiple factors.
   If this happens, run the exponent and bit level again on the CPU or another
   device. You can tell mfakto to run on the CPU using the '-d c' option or use
-  Prime95 instead.
+  Prime95 instead. Lowering GridSize in mfakto.ini can also reduce the chance
+  of error.
 
 - mfakto does not support Intel HD Graphics on macOS
   Due to buggy drivers shipped with macOS, mfakto presently does not work with
@@ -438,7 +440,7 @@ before making changes. ;-)
 #########
 
 Q: Does mfakto support multiple GPUs?
-A: Currently no, but you can use the -d option to tell an instance to run on a
+A: Currently no, but you can use the -d option to start an instance on a
    specific device. Please also see the next question.
 
 Q: Can I run multiple instances of mfakto on the same computer?

--- a/README.txt
+++ b/README.txt
@@ -236,8 +236,8 @@ Other:
 
 
 * without atomics, mfakto may not correctly process multiple factors found in
-the same block / grid. It may report only one factor or even an incorrect one,
-the latter due to scrambled data from multiple factors. PrimeNet automatically
+the same class. It may report only one factor or even an incorrect one, the
+latter due to scrambled data from multiple factors. PrimeNet automatically
 rejects factors that do not divide a Mersenne number. If this happens, run the
 exponent and bit level again on the CPU or another device. You can run mfakto
 on the CPU using the '-d c' option or use Prime95 instead. Lowering GridSize in

--- a/README.txt
+++ b/README.txt
@@ -86,8 +86,8 @@ Steps:
 - install ROCm
 - navigate to the mfakto folder
 - cd src
-- verify that the AMD_APP_DIR variable in the makefile points to the SDK
-  installation directory
+- verify that the AMD_APP_DIR variable in the makefile points to the ROCm
+  directory
 - make
 - mfakto should compile without errors in its root folder
 
@@ -96,24 +96,25 @@ Steps:
 #######################
 
 Requires:
-- Microsoft Visual Studio 2012
+- Microsoft Visual Studio
 - GPUOpen OpenCL SDK
 
 Steps:
-- install the GPUOpen OpenCL SDK
-- launch Visual Studio and open the mfaktoVS12.sln file. You can use a later
-  version as Visual Studio will automatically convert your projects. If the
-  option does not appear, right-click the solution and select "Retarget
-  solution" from the menu.
+- download and install the GPUOpen OpenCL SDK from GitHub:
+  https://github.com/GPUOpen-LibrariesAndSDKs/OCL-SDK/releases
+- open mfaktoVS12.sln in Visual Studio. You can use any recent version as
+  Visual Studio will automatically update your project settings. If the option
+  does not appear, right-click the solution and select "Retarget solution" from
+  the menu.
 - open the project properties and select the configuration and platform
-- go to C/C++ > General > Additional Include Directories and add the path to
-  the OpenCL headers:
+- go to C/C++ > General > Additional Include Directories and verify that it
+  contains the path to the OpenCL headers:
 
       $(OCL_ROOT)\include
 
-- now go to Linker > General > Additional Library Directories and add the path
-  to the appropriate library folder. You may need to restart your computer for
-  Visual Studio to recognize the OCL_ROOT system variable.
+- now go to Linker > General > Additional Library Directories and verify that
+  it contains the correct library path. You may need to restart your computer
+  for Visual Studio to recognize the OCL_ROOT system variable.
 
       32 bits: $(OCL_ROOT)\lib\x86
       64 bits: $(OCL_ROOT)\lib\x86_64
@@ -125,15 +126,18 @@ Steps:
 ########################
 
 Requires:
-- MinGW
+- MinGW (64-bit)
 - GPUOpen OpenCL SDK
 - optional: MSYS2
 
 Initial steps:
-- install the GPUOpen OpenCL SDK
+- download and install a 64-bit MinGW compiler. Our recommendation is to use
+  MinGW-w64 as it is actively maintained: http://mingw-w64.org
+- download and install the GPUOpen OpenCL SDK from GitHub:
+  https://github.com/GPUOpen-LibrariesAndSDKs/OCL-SDK/releases
 - add the "bin" folder in the MinGW directory to your system Path variable
 - verify that the AMD_APP_DIR variable in the makefile points to the SDK
-  installation directory (see note)
+  directory (see note)
 
 MinGW can be used with or without MSYS to compile mfakto. In the latter case:
 - navigate to the mfakto folder
@@ -146,13 +150,23 @@ Otherwise:
 
       pacman -S mingw-w64-x86_64-gcc make
 
-- launch the 32-bit or 64-bit MinGW shell and navigate to the mfakto folder
+- start the 32-bit or 64-bit MinGW shell and navigate to the mfakto folder
 - cd src
 - make (cross your fingers)
 
-Important note: make does not support spaces in file names. If your OpenCL SDK
-installation directory contains spaces, then you will need to either create a
-symbolic link or copy the files to another folder.
+You may see some warnings, but they are safe to ignore.
+
+Additional notes:
+- make does not support spaces in file names. If your OpenCL SDK directory
+  contains spaces, then you will need to either create a symbolic link or copy
+  the files to another folder.
+- mfakto may not compile correctly with Win-builds. It is recommended to use
+  the native Windows package instead:
+  http://mingw-w64.org/doku.php/download/mingw-builds
+- To compile mfakto for both 32 and 64 bits, you will need to install MinGW-w64
+  for both the i686 and x86_64 architectures.
+- mfakto may give an "entry point not found" error on startup. Running make
+  with the "static=yes" flag should prevent this.
 
 #############
 # 1.3 macOS #
@@ -167,17 +181,15 @@ Steps:
 - mfakto should compile out of the box as macOS contains a native OpenCL
   implementation
 
-You may see some warnings, but they are safe to ignore.
-
 ####################
 # 2 Running mfakto #
 ####################
 
 General requirements:
-- AMD Catalyst 11.4 or higher. Consider using 14.4 or above as previous
+- AMD Catalyst 11.4 or higher. Consider using at least 14.4 as some previous
   versions have a bug that causes high CPU loads.
-- AMD APP SDK 2.5 or higher unless using AMD Catalyst 11.10 or above. However,
-  this is not recommended as the AMD APP SDK has been discontinued.
+- AMD APP SDK 2.5 or higher for systems without Catalyst 11.10 or above. It is
+  recommended to update your drivers as the SDK has been discontinued.
 - for Intel integrated GPUs: Compute Runtime for OpenCL
 
 macOS users do not need any additional software as OpenCL is already part of
@@ -213,21 +225,22 @@ AMD:
 - all devices that support OpenCL 1.1 or later
 - all APUs
 - OpenCL 1.0 devices, such as the FireStream 9250 / 9270 and Radeon HD 4000
-  series, can also run mfakto but do not support atomic operations*
+  series, can run mfakto but do not support atomic operations*
 - not supported: FireStream 9170 and Radeon HD 2000 / 3000 series (as kernel
   compilation fails)
 
 Other:
-- Intel HD Graphics 4000 and later. Self-tests currently fail on macOS.
+- Intel HD Graphics 4000 and later. Currently not supported on macOS.
 - OpenCL-enabled CPUs via the '-d c' option
 - not currently supported: Nvidia devices
 
-* without atomics, mfakto does not correctly process multiple factors found in
-the same block / grid. Tests have shown that it will report only one factor. It
-may even return a scrambled factor due to a mix of bytes from multiple factors.
-PrimeNet will automatically reject factors that do not divide a Mersenne
-number. If this happens, rerun the exponent and bit level on the CPU with
-either the '-d c' option or Prime95 / mprime.
+
+* without atomics, mfakto may not correctly process multiple factors found in
+the same block / grid. It may report only one factor or even an incorrect one,
+the latter due to scrambled data from multiple factors. PrimeNet automatically
+rejects factors that do not divide a Mersenne number. If this happens, run the
+exponent and bit level again on the CPU or another device. You can tell mfakto
+to run on the CPU using the '-d c' option or use Prime95 instead.
 
 #############
 # 2.2 Linux #
@@ -241,12 +254,12 @@ either the '-d c' option or Prime95 / mprime.
 ###############
 
 Requirements:
-- AMD Catalyst 11.4 is the minimum required version. Consider using 14.4 or
-  above as previous versions have a bug that causes high CPU loads.
-- AMD APP SDK 2.5 or higher unless using AMD Catalyst 11.10 or above. However,
-  this is not recommended as the AMD APP SDK has been discontinued. If you
-  still want to use it to compile mfakto, make sure the path to the appropriate
-  library folder is in the system Path variable:
+- AMD Catalyst 11.4 or higher. Consider using at least 14.4 as some previous
+  versions have a bug that causes high CPU loads.
+- AMD APP SDK 2.5 or higher for systems without Catalyst 11.10 or above. It is
+  recommended to update your drivers as the SDK has been discontinued.
+  If you still want to use it to compile mfakto, make sure the path to the
+  appropriate library folder is in the system Path variable:
 
       32 bits: %AMDAPPSDKROOT%\lib\x86
       64 bits: %AMDAPPSDKROOT%\lib\x86_64
@@ -355,38 +368,52 @@ Submitting results:
 ##################
 
 - On some devices, such as the Radeon HD 7700 - 7900 series, mfakto may be very
-  slow at full GPU load. It will warn about this during startup.
-  This is due to fewer registers being available to the kernels.
+  slow at full GPU load due to fewer registers being available to the kernels.
+  It will warn about this during startup.
   Set VectorSize=2 in mfakto.ini and restart mfakto to resolve this.
 
 - The user interface has not been extensively tested against invalid inputs.
   Although there are some checks, they are not foolproof by any means.
 
-- Your GUI may lag while running mfakto. In severe cases, Windows may restart
-  the driver or even throw a BSoD.
+- Your GUI may lag while running mfakto. On some Windows systems, the OS may
+  restart the driver or even throw a BSoD in severe cases.
   Try lowering GridSize or NumStreams in your mfakto.ini file. Smaller grids
-  should have better responsiveness at a slight performance loss. To prevent
-  graphics driver crashes on Windows, another option is to increase the GPU
-  processing time: https://support.microsoft.com/en-us/help/2665946
+  should have better responsiveness at a slight performance loss. For Windows
+  users, another option is to increase the GPU processing time:
+  https://support.microsoft.com/en-us/help/2665946
 
-- SievePrimesAdjust is not always optimal. Test it out to find the best
-  SievePrimes value and set SievePrimesAdjust to 0 in your mfakto.ini file.
+- SievePrimesAdjust is not always optimal. Experiment to find the best
+  SievePrimes value and set SievePrimesAdjust=0 in your mfakto.ini file.
 
 - GPU is not found, fallback to CPU
   This happens on Linux when there is no X server. It can also happen on
   Windows when the GPU is not the primary display adapter. Try running mfakto
   on the main display rather than remotely. If that fails, then your graphics
-  driver may be too old. It's also possible that the first GPU is not an AMD
-  one. In this case, use the -d switch to specify a different device number.
-  You can run clinfo to get a list of devices.
+  driver may be too old. It's also possible that the first device is not an
+  AMD GPU. In this case, use the -d switch to specify a different device
+  number. You can run 'clinfo' to get a list of devices.
+
+- on devices that do not support atomic oprations, mfakto may not correctly
+  process multiple factors found in the same block / grid. It may report only
+  one factor or even an incorrect one, the latter due to scrambled data from
+  multiple factors.
+  If this happens, run the exponent and bit level again on the CPU or another
+  device. You can tell mfakto to run on the CPU using the '-d c' option or use
+  Prime95 instead.
+
+- mfakto does not support Intel HD Graphics on macOS
+  Due to buggy drivers shipped with macOS, mfakto presently does not work with
+  Intel HD Graphics. Unless Apple fixes the issue, Intel integrated GPUs may
+  not be supported in the foreseeable future.
+
 
 ##################
 # 4.1 Non-issues #
 ##################
 
 - mfakto runs slower on small ranges. Usually it doesn't make much sense to
-  run mfakto with an upper limit below 64 bits. mfaktc is designed to find
-  factors between 64 and 92 bits and is best suited for long-running jobs.
+  run mfakto with an upper limit below 64 bits. mfakto is designed to find
+  factors between 64 and 92 bits, and is best suited for long-running jobs.
 
 - mfakto can find factors outside the given range.
   This is because mfakto works on huge factor blocks, controlled by GridSize in
@@ -411,8 +438,8 @@ before making changes. ;-)
 #########
 
 Q: Does mfakto support multiple GPUs?
-A: No, but you can use the -d option to tell an instance to run on a specific
-   device. Please also read the next question.
+A: Currently no, but you can use the -d option to tell an instance to run on a
+   specific device. Please also see the next question.
 
 Q: Can I run multiple instances of mfakto on the same computer?
 A: Yes. In most cases, this is necessary to make full use of a GPU when sieving

--- a/src/Makefile
+++ b/src/Makefile
@@ -63,7 +63,7 @@ AMD_APP_LIB = -L$(AMD_APP_DIR)/lib/$(ARCH)
 OPTIMIZE_FLAG = -O3 -funroll-loops  -ffast-math -finline-functions -frerun-loop-opt -fgcse-sm -fgcse-las -flto
 #OPTIMIZE_FLAG = -g
 
-# Compiler settings for .c files (CPU)
+# compiler settings for C and C++ files
 CC = gcc
 CPP = $(CC)
 CFLAGS = $(BITS) -Wall $(OPTIMIZE_FLAG) $(AMD_APP_INCLUDE) -DBUILD_OPENCL

--- a/src/Makefile
+++ b/src/Makefile
@@ -21,44 +21,41 @@
 # Example: "make bitness=32 static=yes" to compile for 32 bits and link
 #          statically
 
-# Check if bitness requested, set x86_64(64bit) as default
-BITS := x86_64
-BITFLAG := -m64
+# set x86_64 (64-bit) as default
+ARCH := x86_64
+BITS := -m64
+
+# check whether to build 32-bit version
 ifdef bitness
   ifeq ($(bitness), 32)
-    BITFLAG := -m32
-    BITS := x86
-  endif
-  ifeq ($(bitness), 64)
-    BITFLAG := -m64
-    BITS := x86_64
+    ARCH := x86
+    BITS := -m32
   endif
 endif
 
-# Check if building statically was requested
+# Check if static linking is requested
 ifdef static
   ifeq ($(static), yes)
     STATIC := -static
   endif
 endif
 
-# some commands won't work on Windows
+# use OS-specific commands
 ifeq ($(OS), Windows_NT)
   CP = copy
-  RM = del /F
+  RM = del /f
 else
   CP = cp
   RM = rm -f
 endif
 
 # where is the OpenCL SDK installed?
+AMD_APP_DIR = /opt/rocm/opencl
+AMD_APP_INCLUDE = -I$(AMD_APP_DIR)/include
+AMD_APP_LIB = -L$(AMD_APP_DIR)/lib/$(ARCH)
 
 # Change needed for compilation with amdgpu-pro
 # AMD_APP_DIR = /opt/amdgpu-pro/opencl
-
-AMD_APP_DIR = /opt/rocm/opencl
-AMD_APP_INCLUDE = -I$(AMD_APP_DIR)/include
-AMD_APP_LIB = -L$(AMD_APP_DIR)/lib/$(BITS)
 
 # optimize or debug
 #OPTIMIZE_FLAG = -O3
@@ -69,8 +66,8 @@ OPTIMIZE_FLAG = -O3 -funroll-loops  -ffast-math -finline-functions -frerun-loop-
 # Compiler settings for .c files (CPU)
 CC = gcc
 CPP = $(CC)
-CFLAGS = $(BITFLAG) -Wall $(OPTIMIZE_FLAG) $(AMD_APP_INCLUDE) -DBUILD_OPENCL
-CPP_FLAGS =
+CFLAGS = $(BITS) -Wall $(OPTIMIZE_FLAG) $(AMD_APP_INCLUDE) -DBUILD_OPENCL
+CPPFLAGS =
 #CFLAGS_EXTRA_SIEVE = -funroll-all-loops
 #CFLAGS_EXTRA_SIEVE = -funroll-all-loops -funsafe-loop-optimizations -fira-region=all -fsched-spec-load -fsched-stalled-insns=10 -fsched-stalled-insns-dep=10 -floop-parallelize-all -fvariable-expansion-in-unroller -fno-align-labels
 CFLAGS_EXTRA_SIEVE = -funroll-all-loops -funsafe-loop-optimizations -fira-region=all -fsched-spec-load -fsched-stalled-insns=10 -fsched-stalled-insns-dep=10 -fno-align-labels
@@ -78,15 +75,16 @@ CFLAGS_EXTRA_SIEVE = -funroll-all-loops -funsafe-loop-optimizations -fira-region
 
 # Linker
 LD = g++
-LDFLAGS = $(BITFLAG) $(STATIC) $(OPTIMIZE_FLAG) $(AMD_APP_LIB) -lOpenCL
+LDFLAGS = $(BITS) $(STATIC) $(OPTIMIZE_FLAG) $(AMD_APP_LIB) -lOpenCL
 
 ##############################################################################
 
-CSRC  = sieve.c timer.c parse.c read_config.c mfaktc.c checkpoint.c \
+CSRC = sieve.c timer.c parse.c read_config.c mfaktc.c checkpoint.c \
 	signal_handler.c filelocking.c output.c
-CLSRC = barrett15.cl  barrett.cl  common.cl  gpusieve.cl  mfakto_Kernels.cl  montgomery.cl  mul24.cl
 
-COBJS  = $(CSRC:.c=.o) mfakto.o gpusieve.o perftest.o menu.o kbhit.o
+# CLSRC = barrett15.cl  barrett.cl  common.cl  gpusieve.cl  mfakto_Kernels.cl  montgomery.cl  mul24.cl
+
+COBJS = $(CSRC:.c=.o) mfakto.o gpusieve.o perftest.o menu.o kbhit.o
 
 ##############################################################################
 
@@ -105,7 +103,7 @@ sieve.o : sieve.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 %.o : %.cpp
-	$(CPP) $(CFLAGS) $(CPP_FLAGS) -c $< -o $@
+	$(CPP) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 ../%.cl : %.cl
 	$(CP) $< ..
@@ -159,5 +157,7 @@ perftest.o: perftest.cpp $(AMD_APP_DIR)/include/CL/cl.h \
  $(AMD_APP_DIR)/include/CL/cl_platform.h params.h my_types.h compatibility.h \
  read_config.h parse.h sieve.h timer.h checkpoint.h filelocking.h \
  signal_handler.h mfakto.h
+
 menu.o: menu.h compatibility.h my_types.h
+
 kbhit.o: kbhit.h

--- a/src/Makefile.macOS
+++ b/src/Makefile.macOS
@@ -21,32 +21,31 @@
 # Run "make -f Makefile.macOS" to compile mfakto for macOS
 
 # Users may see an "out of sync" warning when compiling mfakto. Although
-# harmless, the warning can be resolved by running the following command prior
+# harmless, the warning can be silenced by running the following command prior
 # to compilation:
 #
 # export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 
-BITFLAG := -m64
+ARCH = x86_64
 
-# Compiler settings for .c files (CPU)
+# compiler settings for C and C++ files
 CC = gcc
 CPP = $(CC)
-CFLAGS = $(BITFLAG) -Wall
-CPP_FLAGS =
-
-OPENCLC=/System/Library/Frameworks/OpenCL.framework/Libraries/openclc
+CFLAGS = -arch $(ARCH) -Wall
+CPPFLAGS =
 
 # Linker
 LD = g++
-LDFLAGS = $(BITFLAG)
+LDFLAGS = -arch $(ARCH)
 
 ##############################################################################
 
-CSRC  = sieve.c timer.c parse.c read_config.c mfaktc.c checkpoint.c \
+CSRC = sieve.c timer.c parse.c read_config.c mfaktc.c checkpoint.c \
 	signal_handler.c filelocking.c output.c
-CLSRC = barrett15.cl  barrett.cl  common.cl  gpusieve.cl  mfakto_Kernels.cl  montgomery.cl  mul24.cl
 
-COBJS  = $(CSRC:.c=.o) mfakto.o gpusieve.o perftest.o menu.o kbhit.o
+# CLSRC = barrett15.cl  barrett.cl  common.cl  gpusieve.cl  mfakto_Kernels.cl  montgomery.cl  mul24.cl
+
+COBJS = $(CSRC:.c=.o) mfakto.o gpusieve.o perftest.o menu.o kbhit.o
 
 ##############################################################################
 
@@ -59,13 +58,13 @@ clean :
 	rm -f *.o *~
 
 sieve.o : sieve.c
-	$(CC) $(CFLAGS) $(CFLAGS_EXTRA_SIEVE) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
 
 %.o : %.c
 	$(CC) $(CFLAGS) -c $< -o $@
 
 %.o : %.cpp
-	$(CPP) $(CFLAGS) $(CPP_FLAGS) -c $< -o $@
+	$(CPP) $(CFLAGS) $(CPPFLAGS) -c $< -o $@
 
 ../%.cl : %.cl
 	cp $< ..
@@ -85,35 +84,28 @@ filelocking.o: filelocking.c
 mfaktc.o: mfaktc.c params.h my_types.h compatibility.h \
   sieve.h read_config.h parse.h timer.h checkpoint.h signal_handler.h \
   filelocking.h perftest.h mfakto.h gpusieve.h output.h selftest-data.h
-    $OPENCLC -x cl -cl-std=CL1.2 -Os -arch $* -emit-llvm -o $@ -c $<
 
 output.o: output.c params.h my_types.h output.h filelocking.h compatibility.h
-    $OPENCLC -x cl -cl-std=CL1.2 -Os -arch $* -emit-llvm -o $@ -c $<
 
 parse.o: parse.c compatibility.h filelocking.h parse.h
 
 read_config.o: read_config.c params.h my_types.h
-    $OPENCLC -x cl -cl-std=CL1.2 -Os -arch $* -emit-llvm -o $@ -c $<
 
 sieve.o: sieve.c params.h compatibility.h
 
 signal_handler.o: signal_handler.c params.h my_types.h compatibility.h
-    $OPENCLC -x cl -cl-std=CL1.2 -Os -arch $* -emit-llvm -o $@ -c $<
 
 timer.o: timer.c timer.h compatibility.h
 
 gpusieve.o: gpusieve.cpp my_types.h params.h compatibility.h
-    $OPENCLC -x cl -cl-std=CL1.2 -Os -arch $* -emit-llvm -o $@ -c $<
 
 mfakto.o: mfakto.cpp params.h my_types.h compatibility.h \
- 	read_config.h parse.h sieve.h timer.h checkpoint.h filelocking.h \
- 	perftest.h mfakto.h output.h gpusieve.h signal_handler.h
- 	  $OPENCLC -x cl -cl-std=CL1.2 -Os -arch $* -emit-llvm -o $@ -c $<
+  read_config.h parse.h sieve.h timer.h checkpoint.h filelocking.h \
+  perftest.h mfakto.h output.h gpusieve.h signal_handler.h
 
 perftest.o: perftest.cpp params.h my_types.h compatibility.h \
- 	read_config.h parse.h sieve.h timer.h checkpoint.h filelocking.h \
- 	signal_handler.h mfakto.h
-   	$OPENCLC -x cl -cl-std=CL1.2 -Os -arch $* -emit-llvm -o $@ -c $<
+  read_config.h parse.h sieve.h timer.h checkpoint.h filelocking.h \
+  signal_handler.h mfakto.h
 
 menu.o: menu.h compatibility.h my_types.h
 

--- a/src/compatibility.h
+++ b/src/compatibility.h
@@ -21,17 +21,17 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
   #include <unistd.h> // needed for usleep()
 #endif
 
+/* Windows is not POSIX-compliant */
+#ifdef _MSC_VER
+  #define strncasecmp _strnicmp
+#endif
 
 /* define some format strings */
-#ifdef _MSC_VER
+#if defined __APPLE__ || _MSC_VER
   #define PRId64 "lld"
   #define PRIu64 "llu"
   #define PRIx64 "llx"
-  
-  #define strncasecmp _strnicmp
-#elif __MINGW32__
-  #include <inttypes.h>
-#elif __CYGWIN__
+#elif __MINGW32__ || __CYGWIN__
   #include <inttypes.h>
 #else
   #define PRId64 "Ld"
@@ -47,6 +47,6 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 #ifdef __cplusplus
-#define MAX(a,b)    (((a) > (b)) ? (a) : (b))
-#define MIN(a,b)    (((a) < (b)) ? (a) : (b))
+  #define MAX(a,b)    (((a) > (b)) ? (a) : (b))
+  #define MIN(a,b)    (((a) < (b)) ? (a) : (b))
 #endif

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -1192,7 +1192,7 @@ int main(int argc, char **argv)
 /* print current configuration */
   if(mystuff.verbosity >= 1)
   {
-    printf("Compiletime options\n");
+    printf("Compile-time options\n");
     if (mystuff.gpu_sieving == 0)
     {
 #ifdef SIEVE_SIZE_LIMIT

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -1028,7 +1028,7 @@ int main(int argc, char **argv)
   strcpy(mystuff.inifile, "mfakto.ini");
   mystuff.force_rebuild = 0;
 
-  printf("%s (%dbit build)\n\n", MFAKTO_VERSION, (int)(sizeof(void*)*8));
+  printf("%s (%d-bit build)\n\n", MFAKTO_VERSION, (int)(sizeof(void*)*8));
 
   while(i<argc)
   {
@@ -1196,8 +1196,8 @@ int main(int argc, char **argv)
     if (mystuff.gpu_sieving == 0)
     {
 #ifdef SIEVE_SIZE_LIMIT
-      printf("  SIEVE_SIZE_LIMIT          %dkiB\n", SIEVE_SIZE_LIMIT);
-      printf("  SIEVE_SIZE                %dbits\n", SIEVE_SIZE);
+      printf("  SIEVE_SIZE_LIMIT          %d kiB\n", SIEVE_SIZE_LIMIT);
+      printf("  SIEVE_SIZE                %d bits\n", SIEVE_SIZE);
 #endif
       printf("  SIEVE_SPLIT               %d\n", SIEVE_SPLIT);
     }

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -751,7 +751,7 @@ other return value
   {
     if(mystuff->h_RES[0] == 0)
     {
-      printf("ERROR: selftest failed for M%u (%s)\n", mystuff->exponent, kernel_info[use_kernel].kernelname);
+      printf("ERROR: self-test failed for M%u (%s)\n", mystuff->exponent, kernel_info[use_kernel].kernelname);
       printf("  no factor found\n");
       retval = 1;
     }
@@ -810,7 +810,7 @@ k_max and k_min are used as 64bit temporary integers here...
       }
       if(k_min != 1) /* the factor should appear ONCE */
       {
-        printf("ERROR: selftest failed for M%u (%s)\n", mystuff->exponent, kernel_info[use_kernel].kernelname);
+        printf("ERROR: self-test failed for M%u (%s)\n", mystuff->exponent, kernel_info[use_kernel].kernelname);
         printf("  expected result: %08X %08X %08X\n", f_hi, f_med, f_low);
         for(i=0; (i<mystuff->h_RES[0]) && (i<10); i++)
         {
@@ -820,7 +820,7 @@ k_max and k_min are used as 64bit temporary integers here...
       }
       else
       {
-        if(mystuff->mode != MODE_SELFTEST_SHORT)printf("selftest for M%u passed (%s)!\n", mystuff->exponent, kernel_info[use_kernel].kernelname);
+        if(mystuff->mode != MODE_SELFTEST_SHORT)printf("self-test for M%u passed (%s)!\n", mystuff->exponent, kernel_info[use_kernel].kernelname);
       }
     }
   }
@@ -896,7 +896,7 @@ RET_ERROR we might have a serios problem
       if (i < (sizeof(index)/sizeof(index[0])))
       {
         ind = index[i];
-        printf("######### testcase %d/%d (M%u[%d-%d]) #########\r",
+        printf("######### test case %d/%d (M%u[%d-%d]) #########\r",
           i+1, (int) (sizeof(index)/sizeof(index[0])), st_data[ind].exp, st_data[ind].bit_min, st_data[ind].bit_min + 1);
       }
       else
@@ -905,7 +905,7 @@ RET_ERROR we might have a serios problem
     else // treat type <> 1 as full test
     {
       ind = i;
-      printf("######### testcase %d/%d (M%u[%d-%d]) #########\n",
+      printf("######### test case %d/%d (M%u[%d-%d]) #########\n",
         i+1, total_selftests, st_data[ind].exp, st_data[ind].bit_min, st_data[ind].bit_min + 1);
     }
     f_class = (int)(st_data[ind].k % mystuff->num_classes);
@@ -978,7 +978,7 @@ RET_ERROR we might have a serios problem
     if (mystuff->quit) break;
   }
 
-  printf("Selftest statistics                                    \n");
+  printf("Self-test statistics                                   \n");
   printf("  number of tests           %d\n", num_selftests);
   printf("  successful tests          %d\n", st_success);
   if(st_nofactor > 0)   printf("  no factor found           %d\n", st_nofactor);
@@ -991,12 +991,12 @@ RET_ERROR we might have a serios problem
 
   if(st_success == num_selftests)
   {
-    printf("selftest PASSED!\n\n");
+    printf("self-test PASSED!\n\n");
     retval=0;
   }
   else
   {
-    printf("selftest FAILED!\n\n");
+    printf("self-test FAILED!\n\n");
   }
   mystuff->verbosity = verbosity_save;
   return retval;
@@ -1286,7 +1286,7 @@ int main(int argc, char **argv)
     {
 // macOS does not support setting CPU affinity
 #if !defined __APPLE__
-  // might be best just doing as _WIN32
+  // might be best to just use _WIN32
   #if defined _MSC_VER || __MINGW32__ || __CYGWIN__
         SetThreadAffinityMask(GetCurrentThread(), mystuff.cpu_mask);
   #else
@@ -1307,7 +1307,7 @@ int main(int argc, char **argv)
 
 /* before we start real work run a small selftest */
     mystuff.mode = MODE_SELFTEST_SHORT;
-    if(mystuff.verbosity >= 1) printf("Started a simple selftest ...\n");
+    if(mystuff.verbosity >= 1) printf("Started a simple self-test ...\n");
     if (selftest(&mystuff, MODE_SELFTEST_SHORT) != 0) return ERR_SELFTEST; /* selftest failed :( */
     mystuff.mode = MODE_NORMAL;
     /* allow for ^C */
@@ -1397,7 +1397,7 @@ int main(int argc, char **argv)
   {
     if (0 != selftest(&mystuff, mystuff.mode))
     {
-      printf ("ERROR: selftest failed, exiting.\n");
+      printf ("ERROR: self-test failed, exiting.\n");
       cleanup_CL();
       sieve_free();
       return ERR_SELFTEST;

--- a/src/mfakto.cpp
+++ b/src/mfakto.cpp
@@ -518,7 +518,7 @@ int init_CL(int num_streams, cl_int *devnumber)
   if (strstr(deviceinfo.exts, "global_int32_base_atomics") == NULL)
   {
     printf("\nWARNING: Device does not support atomic operations. This may lead to errors\n"
-           "         when multiple factors are found in the same block. Possible errors\n"
+           "         when multiple factors are found in the same class. Possible errors\n"
            "         include reporting just one of the factors, or (less likely) scrambled\n"
            "         factors. If the reported factor(s) are not accepted by primenet,\n"
            "         please re-run this test on the CPU, or on a GPU with atomics.\n");

--- a/src/output.c
+++ b/src/output.c
@@ -21,7 +21,7 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <math.h>
 #include <time.h>
-#if defined(__APPLE__) || defined(__MACOSX)
+#if defined __APPLE__ || __MACOSX
   #include <OpenCL/cl.h>
 #else
   #include <CL/cl.h>
@@ -44,24 +44,24 @@ void print_help(char *string)
   printf("under certain conditions; see COPYING for details.\n\n\n");
 
   printf("Usage: %s [options]\n", string);
-  printf("  -h|--help              display this help\n");
+  printf("  -h | --help            display this help\n");
   printf("  -d <xy>                specify to use OpenCL platform number x and\n");
   printf("                         device number y in this program\n");
   printf("  -d c                   force using all CPUs\n");
   printf("  -d g                   force using the first GPU\n");
   printf("  -v <n>                 verbosity level: 0=terse, 1=normal, 2=verbose, 3=debug\n");
-  printf("  -tf <exp> <min> <max>  trial factor M<exp> from 2^<min> to 2^<max>\n");
+  printf("  -tf <exp> <min> <max>  trial factor M<exp> from <min> to <max> bits\n");
   printf("                         instead of parsing the worktodo file\n");
-  printf("  -i|--inifile <file>    load <file> as inifile (default: mfakto.ini)\n");
-  printf("  -st                    selftest using the optimal kernel per testcase\n");
-  printf("  -st2                   selftest using all possible kernels\n");
+  printf("  -i | --inifile <file>  load <file> as INI file (default: mfakto.ini)\n");
+  printf("  -st                    self-test using the optimal kernel per test case\n");
+  printf("  -st2                   self-test using all possible kernels\n");
   printf("\n");
   printf("options for debugging purposes\n");
   printf("  --timertest            test of timer functions\n");
   printf("  --sleeptest            test of sleep functions\n");
-  printf("  --perftest [<n>]       performance tests, repeat each test <n> times (def: 10)\n");
+  printf("  --perftest [n]         performance tests, repeat each test <n> times (def: 10)\n");
   printf("  --CLtest               test of some OpenCL functions\n");
-  printf("                         specify -d before --CLtest to test the specified device\n");
+  printf("                         specify -d before --CLtest to test specified device\n");
 }
 
 
@@ -125,7 +125,7 @@ void print_dez96(int96 a, char *buf)
   }
 }
 
-/* unused 
+/* unused
 
 void print_dez144(int144 a, char *buf)
 {
@@ -352,8 +352,8 @@ void print_status_line(mystuff_t *mystuff)
       index = 0;
     }
   }
-  
-  
+
+
   if(mystuff->mode == MODE_NORMAL)
   {
     if(mystuff->printmode == 1)index += sprintf(buffer + index, "\r");

--- a/src/perftest.cpp
+++ b/src/perftest.cpp
@@ -22,7 +22,7 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <fstream>
 #include "string.h"
-#if defined(__APPLE__) || defined(__MACOSX)
+#if defined __APPLE__ || __MACOSX
   #include "OpenCL/cl.h"
 #else
   #include "CL/cl.h"
@@ -1768,8 +1768,10 @@ if (mystuff.more_classes == 1)  strcat(program_options, " -DMORE_CLASSES");
   if (mystuff.small_exp == 1)
     strcat(program_options, " -DSMALL_EXP");
 
-  if (mystuff.CompileOptions[0])  // if mfakto.ini defined compile options, override the default with them
+  // compile options defined in mfakto.ini override the defaults
+  if (mystuff.CompileOptions[0]) {
     strcpy(program_options, mystuff.CompileOptions);
+  }
 
     printf("Compiling kernels (build options: \"%s\").", program_options);
 

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -47,7 +47,7 @@ static int my_read_int(char *inifile, char *name, int *value)
     {
       char msg[80];
       inifile_unavailable = 1;
-      sprintf(msg, "Cannot load inifile \"%.55s\"", inifile);
+      sprintf(msg, "Cannot load INI file \"%.55s\"", inifile);
       perror(msg);
     }
     return 1;
@@ -77,7 +77,7 @@ static int my_read_ulong(char *inifile, char *name, unsigned long long int *valu
     {
       char msg[80];
       inifile_unavailable = 1;
-      sprintf(msg, "Cannot load inifile \"%.55s\"", inifile);
+      sprintf(msg, "Cannot load INI file \"%.55s\"", inifile);
       perror(msg);
     }
     return 1;
@@ -112,7 +112,7 @@ static int my_read_string(char *inifile, char *name, char *string, unsigned int 
     {
       char msg[80];
       inifile_unavailable = 1;
-      sprintf(msg, "Cannot load inifile \"%.55s\"", inifile);
+      sprintf(msg, "Cannot load INI file \"%.55s\"", inifile);
       perror(msg);
     }
     return 1;
@@ -147,7 +147,7 @@ int read_config(mystuff_t *mystuff)
   {
     if(my_read_int(mystuff->inifile, "Verbosity", &i))
     {
-      printf("WARNING: Cannot read Verbosity from inifile, set to 1 by default\n");
+      printf("WARNING: Cannot read Verbosity from INI file, set to 1 by default\n");
       mystuff->verbosity = 1;
     }
     else
@@ -155,14 +155,14 @@ int read_config(mystuff_t *mystuff)
   }
 
   if(mystuff->verbosity >= 1)printf("\nRuntime options\n"
-                                    "  Inifile                   %s\n"
+                                    "  INI file                  %s\n"
                                     "  Verbosity                 %d\n", mystuff->inifile, mystuff->verbosity);
 
 /*****************************************************************************/
 
   if(my_read_int(mystuff->inifile, "SieveOnGPU", &i))
   {
-    printf("WARNING: Cannot read SieveOnGPU from inifile, set to 0 by default\n");
+    printf("WARNING: Cannot read SieveOnGPU from INI file, set to 0 by default\n");
     i=0;
   }
   else if(i != 0 && i != 1)
@@ -187,7 +187,7 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "SievePrimesMin", &i))
     {
-      printf("WARNING: Cannot read SievePrimesMin from inifile, using default value (%d)\n", 5000);
+      printf("WARNING: Cannot read SievePrimesMin from INI file, using default value (%d)\n", 5000);
       i = 5000;
     }
     else if((i < SIEVE_PRIMES_MIN) || (i >= SIEVE_PRIMES_MAX))
@@ -203,7 +203,7 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "SievePrimesMax", &i))
     {
-      printf("WARNING: Cannot read SievePrimesMax from inifile, using default value (%d)\n", 200000);
+      printf("WARNING: Cannot read SievePrimesMax from INI file, using default value (%d)\n", 200000);
       i = 200000;
     }
     else if((i < (int) mystuff->sieve_primes_min) || (i > SIEVE_PRIMES_MAX))
@@ -218,19 +218,19 @@ int read_config(mystuff_t *mystuff)
   /*****************************************************************************/
     if(my_read_int(mystuff->inifile, "SievePrimes", &i))
     {
-      printf("WARNING: Cannot read SievePrimes from inifile, using default value (%d)\n", SIEVE_PRIMES_DEFAULT);
+      printf("WARNING: Cannot read SievePrimes from INI file, using default value (%d)\n", SIEVE_PRIMES_DEFAULT);
       i = SIEVE_PRIMES_DEFAULT;
     }
     else
     {
       if((cl_uint)i>mystuff->sieve_primes_max)
       {
-        printf("WARNING: Read SievePrimes=%d from inifile, using max value (%d)\n", i, mystuff->sieve_primes_max);
+        printf("WARNING: Read SievePrimes=%d from INI file, using max value (%d)\n", i, mystuff->sieve_primes_max);
         i = mystuff->sieve_primes_max;
       }
       else if( i < (int) mystuff->sieve_primes_min)
       {
-        printf("WARNING: Read SievePrimes=%d from inifile, using min value (%d)\n", i, mystuff->sieve_primes_min);
+        printf("WARNING: Read SievePrimes=%d from INI file, using min value (%d)\n", i, mystuff->sieve_primes_min);
         i = mystuff->sieve_primes_min;
       }
     }
@@ -241,7 +241,7 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "SievePrimesAdjust", &i))
     {
-      printf("WARNING: Cannot read SievePrimesAdjust from inifile, using default value (0)\n");
+      printf("WARNING: Cannot read SievePrimesAdjust from INI file, using default value (0)\n");
       i = 0;
     }
     else if(i != 0 && i != 1)
@@ -260,7 +260,7 @@ int read_config(mystuff_t *mystuff)
 #else
     if(my_read_int(mystuff->inifile, "SieveSizeLimit", &i))
     {
-      printf("WARNING: Cannot read SieveSizeLimit from inifile, using default value (32)\n");
+      printf("WARNING: Cannot read SieveSizeLimit from INI file, using default value (32)\n");
       i=32;
     }
     else if(i <= 13*17*19*23/8192)
@@ -277,19 +277,19 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "NumStreams", &i))
     {
-      printf("WARNING: Cannot read NumStreams from inifile, using default value (%d)\n",NUM_STREAMS_DEFAULT);
+      printf("WARNING: Cannot read NumStreams from INI file, using default value (%d)\n",NUM_STREAMS_DEFAULT);
       i=NUM_STREAMS_DEFAULT;
     }
     else
     {
       if(i>NUM_STREAMS_MAX)
       {
-        printf("WARNING: Read NumStreams=%d from inifile, using max value (%d)\n",i,NUM_STREAMS_MAX);
+        printf("WARNING: Read NumStreams=%d from INI file, using max value (%d)\n",i,NUM_STREAMS_MAX);
         i=NUM_STREAMS_MAX;
       }
       else if(i<NUM_STREAMS_MIN)
       {
-        printf("WARNING: Read NumStreams=%d from inifile, using min value (%d)\n",i,NUM_STREAMS_MIN);
+        printf("WARNING: Read NumStreams=%d from INI file, using min value (%d)\n",i,NUM_STREAMS_MIN);
         i=NUM_STREAMS_MIN;
       }
     }
@@ -324,19 +324,19 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "GridSize", &i))
     {
-      printf("WARNING: Cannot read GridSize from inifile, using default value (3)\n");
+      printf("WARNING: Cannot read GridSize from INI file, using default value (3)\n");
       i = 3;
     }
     else
     {
       if(i > 4)
       {
-        printf("WARNING: Read GridSize=%d from inifile, using max value (4)\n", i);
+        printf("WARNING: Read GridSize=%d from INI file, using max value (4)\n", i);
         i = 4;
       }
       else if(i < 0)
       {
-        printf("WARNING: Read GridSize=%d from inifile, using min value (0)\n", i);
+        printf("WARNING: Read GridSize=%d from INI file, using min value (0)\n", i);
         i = 0;
       }
     }
@@ -351,7 +351,7 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_ulong(mystuff->inifile, "SieveCPUMask", &ul))
     {
-      printf("WARNING: Cannot read SieveCPUMask from inifile, set to 0 by default\n");
+      printf("WARNING: Cannot read SieveCPUMask from INI file, set to 0 by default\n");
       ul=0;
     }
     #ifdef __MINGW32__
@@ -390,7 +390,7 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "MoreClasses", &i))
     {
-      printf("WARNING: Cannot read MoreClasses from inifile, set to 1 by default\n");
+      printf("WARNING: Cannot read MoreClasses from INI file, set to 1 by default\n");
       i=1;
     }
     else if(i != 0 && i != 1)
@@ -410,19 +410,19 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "GPUSievePrimes", &i))
     {
-      printf("WARNING: Cannot read GPUSievePrimes from inifile, using default value (%d)\n",GPU_SIEVE_PRIMES_DEFAULT);
+      printf("WARNING: Cannot read GPUSievePrimes from INI file, using default value (%d)\n",GPU_SIEVE_PRIMES_DEFAULT);
       i = GPU_SIEVE_PRIMES_DEFAULT;
     }
     else
     {
       if(i > GPU_SIEVE_PRIMES_MAX)
       {
-        printf("WARNING: Read GPUSievePrimes=%d from inifile, using max value (%d)\n",i,GPU_SIEVE_PRIMES_MAX);
+        printf("WARNING: Read GPUSievePrimes=%d from INI file, using max value (%d)\n",i,GPU_SIEVE_PRIMES_MAX);
         i = GPU_SIEVE_PRIMES_MAX;
       }
       else if(i < GPU_SIEVE_PRIMES_MIN)
       {
-        printf("WARNING: Read GPUSievePrimes=%d from inifile, using min value (%d)\n",i,GPU_SIEVE_PRIMES_MIN);
+        printf("WARNING: Read GPUSievePrimes=%d from INI file, using min value (%d)\n",i,GPU_SIEVE_PRIMES_MIN);
         i = GPU_SIEVE_PRIMES_MIN;
       }
     }
@@ -433,7 +433,7 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "GPUSieveProcessSize", &i))
     {
-      printf("WARNING: Cannot read GPUSieveProcessSize from inifile, using default value (%d)\n",GPU_SIEVE_PROCESS_SIZE_DEFAULT);
+      printf("WARNING: Cannot read GPUSieveProcessSize from INI file, using default value (%d)\n",GPU_SIEVE_PROCESS_SIZE_DEFAULT);
       i = GPU_SIEVE_PROCESS_SIZE_DEFAULT;
     }
     else
@@ -446,12 +446,12 @@ int read_config(mystuff_t *mystuff)
       }
       if(i > GPU_SIEVE_PROCESS_SIZE_MAX)
       {
-        printf("WARNING: Read GPUSieveProcessSize=%d from inifile, using max value (%d)\n",i,GPU_SIEVE_PROCESS_SIZE_MAX);
+        printf("WARNING: Read GPUSieveProcessSize=%d from INI file, using max value (%d)\n",i,GPU_SIEVE_PROCESS_SIZE_MAX);
         i = GPU_SIEVE_PROCESS_SIZE_MAX;
       }
       else if(i < GPU_SIEVE_PROCESS_SIZE_MIN)
       {
-        printf("WARNING: Read GPUSieveProcessSize=%d from inifile, using min value (%d)\n",i,GPU_SIEVE_PROCESS_SIZE_MIN);
+        printf("WARNING: Read GPUSieveProcessSize=%d from INI file, using min value (%d)\n",i,GPU_SIEVE_PROCESS_SIZE_MIN);
         i = GPU_SIEVE_PROCESS_SIZE_MIN;
       }
     }
@@ -462,19 +462,19 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "GPUSieveSize", &i))
     {
-      printf("WARNING: Cannot read GPUSieveSize from inifile, using default value (%d)\n",GPU_SIEVE_SIZE_DEFAULT);
+      printf("WARNING: Cannot read GPUSieveSize from INI file, using default value (%d)\n",GPU_SIEVE_SIZE_DEFAULT);
       i = GPU_SIEVE_SIZE_DEFAULT;
     }
     else
     {
       if(i > GPU_SIEVE_SIZE_MAX)
       {
-        printf("WARNING: Read GPUSieveSize=%d from inifile, using max value (%d)\n",i,GPU_SIEVE_SIZE_MAX);
+        printf("WARNING: Read GPUSieveSize=%d from INI file, using max value (%d)\n",i,GPU_SIEVE_SIZE_MAX);
         i = GPU_SIEVE_SIZE_MAX;
       }
       else if(i < GPU_SIEVE_SIZE_MIN)
       {
-        printf("WARNING: Read GPUSieveSize=%d from inifile, using min value (%d)\n",i,GPU_SIEVE_SIZE_MIN);
+        printf("WARNING: Read GPUSieveSize=%d from INI file, using min value (%d)\n",i,GPU_SIEVE_SIZE_MIN);
         i = GPU_SIEVE_SIZE_MIN;
       }
       if (i * 1024 * 1024 % mystuff->gpu_sieve_processing_size != 0)
@@ -493,14 +493,14 @@ int read_config(mystuff_t *mystuff)
 
     if(my_read_int(mystuff->inifile, "FlushInterval", &i))
     {
-      printf("WARNING: Cannot read FlushInterval from inifile, using default value 0\n");
+      printf("WARNING: Cannot read FlushInterval from INI file, using default value 0\n");
       i = 0;
     }
     else
     {
       if(i < 0)
       {
-        printf("WARNING: Read FlushInterval=%d from inifile, using min value (0)\n",i);
+        printf("WARNING: Read FlushInterval=%d from INI file, using min value (0)\n",i);
         i = 0;
       }
     }
@@ -513,7 +513,7 @@ int read_config(mystuff_t *mystuff)
   if(my_read_string(mystuff->inifile, "WorkFile", mystuff->workfile, 50))
   {
     sprintf(mystuff->workfile, "worktodo.txt");
-    printf("WARNING: Cannot read WorkFile from inifile, using default (%s)\n", mystuff->workfile);
+    printf("WARNING: Cannot read WorkFile from INI file, using default (%s)\n", mystuff->workfile);
   }
   if(mystuff->verbosity >= 1)printf("  WorkFile                  %s\n", mystuff->workfile);
 
@@ -522,7 +522,7 @@ int read_config(mystuff_t *mystuff)
   if(my_read_string(mystuff->inifile, "ResultsFile", mystuff->resultfile, 50))
   {
     sprintf(mystuff->resultfile, "results.txt");
-    printf("WARNING: Cannot read ResultsFile from inifile, using default (%s)\n", mystuff->resultfile);
+    printf("WARNING: Cannot read ResultsFile from INI file, using default (%s)\n", mystuff->resultfile);
   }
   if(mystuff->verbosity >= 1)printf("  ResultsFile               %s\n", mystuff->resultfile);
 
@@ -530,7 +530,7 @@ int read_config(mystuff_t *mystuff)
 
   if(my_read_int(mystuff->inifile, "Checkpoints", &i))
   {
-    printf("WARNING: Cannot read Checkpoints from inifile, enabled by default\n");
+    printf("WARNING: Cannot read Checkpoints from INI file, enabled by default\n");
     i=1;
   }
   else if(i < 0)
@@ -556,17 +556,17 @@ int read_config(mystuff_t *mystuff)
   {
     if(my_read_int(mystuff->inifile, "CheckpointDelay", &i))
     {
-      printf("WARNING: Cannot read CheckpointDelay from inifile, set to 300s by default\n");
+      printf("WARNING: Cannot read CheckpointDelay from INI file, set to 300 s by default\n");
       i = 300;
     }
     if(i > 3600)
     {
-      printf("WARNING: Maximum value for CheckpointDelay is 3600s\n");
+      printf("WARNING: Maximum value for CheckpointDelay is 3600 s\n");
       i = 3600;
     }
     if(i < 0)
     {
-      printf("WARNING: Minimum value for CheckpointDelay is 0s\n");
+      printf("WARNING: Minimum value for CheckpointDelay is 0 s\n");
       i = 0;
     }
     if(mystuff->verbosity >= 1)printf("  CheckpointDelay           %d s\n", i);
@@ -577,7 +577,7 @@ int read_config(mystuff_t *mystuff)
 
   if(my_read_int(mystuff->inifile, "Stages", &i))
   {
-    printf("WARNING: Cannot read Stages from inifile, enabled by default\n");
+    printf("WARNING: Cannot read Stages from INI file, enabled by default\n");
     i=1;
   }
   else if(i != 0 && i != 1)
@@ -596,7 +596,7 @@ int read_config(mystuff_t *mystuff)
 
   if(my_read_int(mystuff->inifile, "StopAfterFactor", &i))
   {
-    printf("WARNING: Cannot read StopAfterFactor from inifile, set to 1 by default\n");
+    printf("WARNING: Cannot read StopAfterFactor from INI file, set to 1 by default\n");
     i=1;
   }
   else if( (i < 0) || (i > 2) )
@@ -616,7 +616,7 @@ int read_config(mystuff_t *mystuff)
 
   if(my_read_int(mystuff->inifile, "PrintMode", &i))
   {
-    printf("WARNING: Cannot read PrintMode from inifile, set to 0 by default\n");
+    printf("WARNING: Cannot read PrintMode from INI file, set to 0 by default\n");
     i=0;
   }
   else if(i != 0 && i != 1)
@@ -664,7 +664,7 @@ int read_config(mystuff_t *mystuff)
   {
 //    sprintf(mystuff->stats.progressheader, "    class | candidates |    time |    ETA | avg. rate | SievePrimes | CPU wait");
     sprintf(mystuff->stats.progressheader, "Date   Time     Pct    ETA | Exponent    Bits | GHz-d/day    Sieve     Wait");
-    printf("WARNING, no ProgressHeader specified in inifile, using default\n");
+    printf("WARNING: no ProgressHeader specified in INI file, using default\n");
   }
   if(mystuff->verbosity >= 2)printf("  ProgressHeader            \"%s\"\n", mystuff->stats.progressheader);
 
@@ -674,7 +674,7 @@ int read_config(mystuff_t *mystuff)
   if(my_read_string(mystuff->inifile, "ProgressFormat", mystuff->stats.progressformat, 250))
   {
     sprintf(mystuff->stats.progressformat, "%%d %%T  %%p %%e | %%M %%l-%%u |   %%g  %%s  %%W%%%%");
-    printf("WARNING, no ProgressFormat specified in inifile, using default\n");
+    printf("WARNING: no ProgressFormat specified in INI file, using default\n");
   }
   if(mystuff->verbosity >= 2)printf("  ProgressFormat            \"%s\"\n", mystuff->stats.progressformat);
 
@@ -702,7 +702,7 @@ int read_config(mystuff_t *mystuff)
 
   if(my_read_int(mystuff->inifile, "VectorSize", &i))
   {
-    printf("WARNING: Cannot read VectorSize from inifile, set to 4 by default\n");
+    printf("WARNING: Cannot read VectorSize from INI file, set to 4 by default\n");
     i=4;
   }
   else if((i < 1 || i > 4) && i != 8 && i != 16 )
@@ -724,7 +724,7 @@ int read_config(mystuff_t *mystuff)
 
   if (my_read_string(mystuff->inifile, "GPUType", tmp, 50))
   {
-    printf("WARNING: Cannot read GPUType from inifile, using default (AUTO)\n");
+    printf("WARNING: Cannot read GPUType from INI file, using default (AUTO)\n");
     strcpy(tmp, "AUTO");
     mystuff->gpu_type = GPU_AUTO;
   }
@@ -753,7 +753,7 @@ int read_config(mystuff_t *mystuff)
 
   if(my_read_int(mystuff->inifile, "SmallExp", &i))
   {
-    printf("WARNING: Cannot read SmallExp from inifile, set to 0 by default\n");
+    printf("WARNING: Cannot read SmallExp from INI file, set to 0 by default\n");
     i=0;
   }
   else if(i != 0 && i != 1)
@@ -815,7 +815,7 @@ int read_array(char *filename, char *keyname, cl_uint num, cl_uint *arr)
     {
       char msg[80];
       inifile_unavailable = 1;
-      sprintf(msg, "Cannot load inifile \"%.55s\"", filename);
+      sprintf(msg, "Cannot load INI file \"%.55s\"", filename);
       perror(msg);
     }
     return 1;

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -19,8 +19,12 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
 #include <stdio.h>
 #include <string.h>
-#if defined(BUILD_OPENCL)
-#include <CL/cl.h>
+#if defined BUILD_OPENCL
+  #if defined __APPLE__ || __MACOSX
+    #include <OpenCL/cl.h>
+  #else
+    #include <CL/cl.h>
+  #endif
 #endif
 
 #include "params.h"

--- a/src/sieve.c
+++ b/src/sieve.c
@@ -23,7 +23,7 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 
 #include "params.h"
 #ifdef VERBOSE_SIEVE_TIMING
-#include "timer.h"
+  #include "timer.h"
 #endif
 #include "compatibility.h"
 #include "gpusieve.h"
@@ -53,28 +53,30 @@ the position of the set bits
 for 0 <= n < 256 */
 static unsigned int sieve_table[256][9];
 
-static __inline unsigned int sieve_get_bit(unsigned int *array,unsigned int bit)
+static __inline unsigned int sieve_get_bit(unsigned int *array, unsigned int bit)
 {
   unsigned int chunk;
-  chunk=bit>>5;
-  bit&=0x1F;
-  return array[chunk]&mask1[bit];
+  chunk = bit >> 5;
+  bit &= 0x1F;
+  return array[chunk] & mask1[bit];
 }
 
-static __inline void sieve_set_bit(unsigned int *array,unsigned int bit)
+/*
+static __inline void sieve_set_bit(unsigned int *array, unsigned int bit)
 {
   unsigned int chunk;
-  chunk=bit>>5;
-  bit&=0x1F;
-  array[chunk]|=mask1[bit];
+  chunk = bit >> 5;
+  bit &= 0x1F;
+  array[chunk] |= mask1[bit];
 }
+*/
 
-static __inline void sieve_clear_bit(unsigned int *array,unsigned int bit)
+static __inline void sieve_clear_bit(unsigned int *array, unsigned int bit)
 {
   unsigned int chunk;
-  chunk=bit>>5;
-  bit&=0x1F;
-  array[chunk]&=mask0[bit];
+  chunk = bit >> 5;
+  bit &= 0x1F;
+  array[chunk] &= mask0[bit];
 }
 //#define sieve_clear_bit(ARRAY,BIT) asm("btrl  %0, %1" : /* no output */ : "r" (BIT), "m" (*ARRAY) : "memory", "cc" )
 //#define sieve_clear_bit(ARRAY,BIT) ARRAY[BIT>>5]&=mask0[BIT&0x1F]
@@ -146,21 +148,21 @@ void sieve_free()
 int sieve_euclid_modified(int j, int n, int r)
 /*
 (k*j) % n = r
-calculates and returns k 
+calculates and returns k
 */
 {
 /* using long long int because I'm too lazy to figure out where I can live with
 smaller ints
 j, n, r  <=  primes[200000] = 2750161 (22 bits) */
   long long int nn,nn_old,jj,pi0,pi1,pi2,qi0,qi1,qi2,tmp;
-  
+
   if(r==0)return 0;	/* trivially! */
   if(j==1)return r;	/* easy, isn't it? */
 //  if(j+1 == n) return (n-r); // TODO: PERF: would this help?
 
   nn_old=n;
   jj=j;
-  
+
 /*** step 0 ***/
   qi0=nn_old/jj;
   nn=nn_old%jj;
@@ -209,17 +211,17 @@ void sieve_init_class(unsigned int exp, unsigned long long int k_start, unsigned
   unsigned int i,j,k,p;
   unsigned int ii,jj;
 
-#ifdef MORE_CLASSES  
+#ifdef MORE_CLASSES
   for(i=4;i<sieve_limit;i++)
 #else
   for(i=3;i<sieve_limit;i++)
-#endif  
+#endif
   {
     //unsigned long long int check;
 
-    p=primes[i];  
+    p=primes[i];
     k=0;
-// oldest version, explains what happens here a little bit */    
+// oldest version, explains what happens here a little bit */
 //    while((2 * (exp%p) * ((k_start+k*NUM_CLASSES)%p)) %p != (p-1))k++;
 
 
@@ -264,14 +266,14 @@ still a brute force trial&error method */
       printf("  check= %" PRId64 "\n",check);
     } */
   }
-  
+
   // set all bits
   for(i=0;i<SIEVE_WORDS;i++) sieve_base[i] = 0xFFFFFFFF;
 
 #ifdef MORE_CLASSES
 /* presieve 13, 17, 19 and 23 in sieve_base */
   for(i=4;i<=7;i++)
-#else  
+#else
 /* presieve 11, 13, 17 and 19 in sieve_base */
   for(i=3;i<=6;i++)
 #endif
@@ -303,10 +305,10 @@ void sieve_candidates(unsigned int ktab_size, unsigned int *ktab, unsigned int s
 #endif
 
 #ifdef RAW_GPU_BENCH
-//  quick hack to "speed up the siever", used for GPU-code benchmarks  
+//  quick hack to "speed up the siever", used for GPU-code benchmarks
   for(i=0;i<ktab_size;i++)ktab[i]=i;
   return;
-#endif  
+#endif
 
   if(last_sieve < (int)SIEVE_SIZE)
   {
@@ -383,7 +385,7 @@ this behaviour and precompute them. :)
       }
       k_init[i]=j-SIEVE_SIZE;
     }
-    
+
 #ifdef VERBOSE_SIEVE_TIMING
   printf("Sieve done: %llu\n", timer_diff(&timer));
 #endif
@@ -391,7 +393,7 @@ this behaviour and precompute them. :)
 /*
 we have finished sieving and now we need to translate the remaining bits in
 the sieve to the correspondic k_tab offsets
-*/    
+*/
 
 /* part one of the loop:
 Get the bits out of the sieve until i is a multiple of 32
@@ -430,13 +432,13 @@ b) ktab is nearly filled up */
 #ifdef SIEVER_OLD_METHOD
       sieve_table_=sieve_table[ s     &0xFF];
       for(p=0;p<sieve_table_[8];p++) ktab[k++]=ic   +sieve_table_[p];
-      
+
       sieve_table_=sieve_table[(s>>8 )&0xFF];
       for(p=0;p<sieve_table_[8];p++) ktab[k++]=ic +8+sieve_table_[p];
-      
+
       sieve_table_=sieve_table[(s>>16)&0xFF];
       for(p=0;p<sieve_table_[8];p++) ktab[k++]=ic+16+sieve_table_[p];
-      
+
       sieve_table_=sieve_table[ s>>24      ];
       for(p=0;p<sieve_table_[8];p++) ktab[k++]=ic+24+sieve_table_[p];
 
@@ -455,7 +457,7 @@ b) ktab is nearly filled up */
         ktab[k+7]=ic+sieve_table_[7];
       }
       k+=sieve_table_8;
-      
+
       sieve_table_=sieve_table[(s>>8 )&0xFF];
       sieve_table_8=sieve_table_[8];
       ic+=8;
@@ -471,7 +473,7 @@ b) ktab is nearly filled up */
         ktab[k+7]=ic+sieve_table_[7];
       }
       k+=sieve_table_8;
-      
+
       sieve_table_=sieve_table[(s>>16)&0xFF];
       sieve_table_8=sieve_table_[8];
       ic+=8;
@@ -487,7 +489,7 @@ b) ktab is nearly filled up */
         ktab[k+7]=ic+sieve_table_[7];
       }
       k+=sieve_table_8;
-      
+
       sieve_table_=sieve_table[ s>>24      ];
       sieve_table_8=sieve_table_[8];
       ic+=8;
@@ -503,7 +505,7 @@ b) ktab is nearly filled up */
         ktab[k+7]=ic+sieve_table_[7];
       }
       k+=sieve_table_8;
-#endif      
+#endif
     }
 #ifdef VERBOSE_SIEVE_TIMING
   printf("Extract 2  : %llu\n", timer_diff(&timer));
@@ -513,7 +515,7 @@ b) ktab is nearly filled up */
 Get the bits out of the sieve until
 a) sieve ends
 or
-b) ktab is full */    
+b) ktab is full */
     for(;(unsigned int)i<SIEVE_SIZE;i++)
     {
       if(sieve_get_bit(sieve,i))
@@ -555,4 +557,3 @@ unsigned int sieve_sieve_primes_max(unsigned int exp, unsigned int sieve_max)
 #ifdef __cplusplus
 }
 #endif
-

--- a/src/signal_handler.c
+++ b/src/signal_handler.c
@@ -20,8 +20,12 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#if defined(BUILD_OPENCL)
-#include <CL/cl.h>
+#if defined BUILD_OPENCL
+  #if defined __APPLE__ || __MACOSX
+    #include <OpenCL/cl.h>
+  #else
+    #include <CL/cl.h>
+  #endif
 #endif
 
 #include "params.h"
@@ -39,7 +43,7 @@ void my_signal_handler(int signum)
 invoked so we just register it again. */
   signal(signum, &my_signal_handler);
 #endif
-  
+
   signal_handler_mystuff->quit++;
   if(signal_handler_mystuff->quit == 1)
   {


### PR DESCRIPTION
* macOS users should no longer get compiler warnings
* fixed some more potential macOS compilation errors
* enabled universal x86_64 builds for macOS
* resolved redundancies in makefiles
* made output text more consistent
* updated the documentation to include MinGW troubleshooting information