### PR TITLE
add fix for DETAILED_INFO

### DIFF
--- a/src/compatibility.h
+++ b/src/compatibility.h
@@ -27,11 +27,11 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #endif
 
 /* define some format strings */
-#if defined __APPLE__ || _MSC_VER
+#if defined __APPLE__ || defined _MSC_VER
   #define PRId64 "lld"
   #define PRIu64 "llu"
   #define PRIx64 "llx"
-#elif __MINGW32__ || __CYGWIN__
+#elif __MINGW32__ || defined __CYGWIN__
   #include <inttypes.h>
 #else
   #define PRId64 "Ld"

--- a/src/filelocking.c
+++ b/src/filelocking.c
@@ -25,7 +25,7 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #include <string.h>
 #include <time.h>
 
-#if defined _MSC_VER || __MINGW32__
+#if defined _MSC_VER || defined __MINGW32__
   #include <Windows.h>
   #include <io.h>
   #include <direct.h>

--- a/src/gpusieve.cpp
+++ b/src/gpusieve.cpp
@@ -29,7 +29,7 @@ See (http://www.mersenneforum.org/showthread.php?t=11900) for Ben's initial work
 */
 
 #include <cstdlib>
-#if defined(__APPLE__) || defined(__MACOSX)
+#if defined __APPLE__
   #include "OpenCL/cl.h"
 #else
   #include "CL/cl.h"

--- a/src/mfaktc.c
+++ b/src/mfaktc.c
@@ -24,7 +24,7 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
   #include <unistd.h>
   #include <sched.h>
 #endif
-#if defined __MINGW32__ || __CYGWIN__
+#if defined __MINGW32__ || defined __CYGWIN__
   #include <windows.h>
 #endif
 #include <string.h>
@@ -1287,7 +1287,7 @@ int main(int argc, char **argv)
 // macOS does not support setting CPU affinity
 #if !defined __APPLE__
   // might be best to just use _WIN32
-  #if defined _MSC_VER || __MINGW32__ || __CYGWIN__
+  #if defined _MSC_VER || defined __MINGW32__ || defined __CYGWIN__
         SetThreadAffinityMask(GetCurrentThread(), mystuff.cpu_mask);
   #else
         sched_setaffinity(0, sizeof(mystuff.cpu_mask), (cpu_set_t *)&(mystuff.cpu_mask));

--- a/src/mfakto.cpp
+++ b/src/mfakto.cpp
@@ -2699,6 +2699,7 @@ int tf_class_opencl(cl_ulong k_min, cl_ulong k_max, mystuff_t *mystuff, enum GPU
   // as a first test, copy the sieve bits into the usual sieve array - later, the kernels will do that.
         static double peak=0.0;
         cl_uint ind=0, pos=0, *dest=mystuff->h_ktab[h_ktab_index];
+        int total_overflows = 0;
         for (i=0; i<mystuff->gpu_sieve_size/32; i++)
         {
           cl_uint ii, word=mystuff->h_bitarray[i];
@@ -2726,9 +2727,14 @@ int tf_class_opencl(cl_ulong k_min, cl_ulong k_max, mystuff_t *mystuff, enum GPU
               }*/
             }
             pos++;
-            if (pos > 0xffffff) printf("Overflow!\n");
+            if (pos > 0xffffff) {
+                total_overflows++;
+            }
             word >>= 1;
           }
+        }
+        if (total_overflows > 0) {
+            printf("Overflow occured %u times for exponent %u in tf_class_opencl()\n", total_overflows, mystuff->exponent);
         }
         if (peak < (double) ind * 100.0 / (double) pos) peak=(double) ind * 100.0 / (double) pos;
         printf("bit-extract: %u/%u words (%u bits) processed, %u bits set (%f%% -- max=%f%% @ %u).\n",

--- a/src/mfakto.cpp
+++ b/src/mfakto.cpp
@@ -2282,7 +2282,7 @@ __kernel void cl_barrett32_77_gs(__private uint exp, const int96_t k_base, const
 
 //  shared_mem_required = (shared_mem_required + 127) & 0xFFFFFF80; // 128-byte-multiple
 #ifdef DETAILED_INFO
-  printf("run_gs_kernel: shared_mem: %u, loc/glob threads: %u/%u\n", shared_mem_required, localThreads, globalThreads);
+  printf("run_gs_kernel: shared_mem: %u, loc/glob threads: %zu/%zu\n", shared_mem_required, localThreads, globalThreads);
 #endif
   if (new_class)
   {

--- a/src/my_types.h
+++ b/src/my_types.h
@@ -22,7 +22,7 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #ifndef __MY_TYPES_H
 #define __MY_TYPES_H
 #include "params.h"
-#if defined __APPLE__ || __MACOSX
+#if defined __APPLE__
   #include "OpenCL/cl.h"
 #else
   #include "CL/cl.h"

--- a/src/output.c
+++ b/src/output.c
@@ -21,7 +21,7 @@ along with mfaktc.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <math.h>
 #include <time.h>
-#if defined __APPLE__ || __MACOSX
+#if defined __APPLE__
   #include <OpenCL/cl.h>
 #else
   #include <CL/cl.h>

--- a/src/perftest.cpp
+++ b/src/perftest.cpp
@@ -24,7 +24,7 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #include <iostream>
 #include <fstream>
 #include "string.h"
-#if defined __APPLE__ || __MACOSX
+#if defined __APPLE__
   #include "OpenCL/cl.h"
 #else
   #include "CL/cl.h"

--- a/src/perftest.cpp
+++ b/src/perftest.cpp
@@ -917,7 +917,7 @@ GPUKernels test_cpu_tf_kernels(cl_uint par)
   shiftcount=10;  // no exp below 2^10 ;-)
   while((1ULL<<shiftcount) < (unsigned long long int)mystuff.exponent)shiftcount++;
 #ifdef DETAILED_INFO
-  printf("bits in exp %u: %u, ", mystuff->exponent, shiftcount);
+  printf("bits in exp %u: %u, ", mystuff.exponent, shiftcount);
 #endif
   shiftcount -= 6; // all kernels can handle 5 bits of pre-shift (max 2^63)
   ln2b = mystuff.exponent >> shiftcount;

--- a/src/read_config.c
+++ b/src/read_config.c
@@ -20,7 +20,7 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <string.h>
 #if defined BUILD_OPENCL
-  #if defined __APPLE__ || __MACOSX
+  #if defined __APPLE__
     #include <OpenCL/cl.h>
   #else
     #include <CL/cl.h>

--- a/src/signal_handler.c
+++ b/src/signal_handler.c
@@ -21,7 +21,7 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <stdlib.h>
 #if defined BUILD_OPENCL
-  #if defined __APPLE__ || __MACOSX
+  #if defined __APPLE__
     #include <OpenCL/cl.h>
   #else
     #include <CL/cl.h>


### PR DESCRIPTION
- mfakto no longer throws errors or warnings when compiled with the `DETAILED_INFO` flag
- mfakto no longer prints "Overflow!" 80 million times when `DETAILED_INFO` is set
- corrected some C preprocessor directives