### PR TITLE
fix CHECKS_MODBASECASE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 *.o
 *.obj
 *~
-src/depend.tmp
+src/*.tmp
+src/depend
 
 # binaries
 mfakto
@@ -12,13 +13,12 @@ mfakto
 # copied from source directory
 *.cl
 !src/*.cl
-*.exe
 *.h
 !src/*.h
 *.ini
 !src/*.ini
 
-# machine-specific Visual Studio files
+# device-specific Visual Studio files
 *.suo
 *.sdf
 *.opensdf
@@ -28,12 +28,7 @@ mfakto
 ipch/
 Release/
 Debug/
-Release/
-ipch/
-mfakto
-mfakto_Kernels.elf
 src/all
-src/depend
 x64/
 
 # instance-specific files

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ mfakto
 ipch/
 Release/
 Debug/
-src/all
 x64/
 
 # instance-specific files

--- a/src/mfakto_Kernels.cl
+++ b/src/mfakto_Kernels.cl
@@ -99,8 +99,8 @@ Version 0.15
 // this kernel is only used for a quick test at startup - no need to be correct ;-)
 // currently this kernel is used for testing what happens without atomics when multiple factors are found
 __kernel void test_k(const ulong hi, const ulong lo, const ulong q,
-                           const float qr, __global uint *res
-)
+                        const float qr, __global uint *res
+                        MODBASECASE_PAR_DEF)
 {
   __private uint i,f, tid;
   int180_v resv;
@@ -264,9 +264,9 @@ __kernel void test_k(const ulong hi, const ulong lo, const ulong q,
   div_180_90(&r, i, a, ff
 #endif
 #if (TRACE_KERNEL > 1)
-                  , tid
+                , tid
 #endif
-                  );
+                MODBASECASE_PAR);
   // enforce evaluation ... otherwise some calculations are optimized away ;-)
   res[30] = V(r.d5) + V(r.d4) + V(r.d3) + V(r.d2) + V(r.d1) + V(r.d0);
 
@@ -296,9 +296,9 @@ __kernel void test_k(const ulong hi, const ulong lo, const ulong q,
   div_180_90(&r, i, b, ff
 #endif
 #if (TRACE_KERNEL > 1)
-                  , tid
+                , tid
 #endif
-                  );
+                MODBASECASE_PAR);
   // enforce evaluation ... otherwise some calculations are optimized away ;-)
   //res[31] = r.d5.s0 + r.d4.s0 + r.d3.s0 + r.d2.s0 + r.d1.s0 + r.d0.s0;
 

--- a/src/tf_debug.h
+++ b/src/tf_debug.h
@@ -32,7 +32,7 @@ D = index for modbasecase_debug[];
   #define MODBASECASE_QI_ERROR(A, B, C, D) \
   if(C > (A)) \
   { \
-    printf((__constant char *)"EEEEEK, step %lld qi = %x, tid=%u\n", B, C, get_global_id(0)); \
+    printf((__constant char *)"warning: step %lld qi = %x, tid=%u\n", B, C, get_global_id(0)); \
     modbasecase_debug[D]++; \
   }
 #else
@@ -55,7 +55,7 @@ D = index for modbasecase_debug[];
   #define MODBASECASE_NONZERO_ERROR(A, B, C, D) \
   if(A) \
   { \
-    printf((__constant char *)"EEEEEK, step %d q.d%d is nonzero: %u, tid=%u\n", B, C, A, get_global_id(0)); \
+    printf((__constant char *)"warning: step %d q.d%d is non-zero: %u, tid=%u\n", B, C, A, get_global_id(0)); \
     modbasecase_debug[D]++; \
   }
 #else
@@ -78,7 +78,7 @@ D = index for modbasecase_debug[];
   #define MODBASECASE_NN_BIG_ERROR(A, B, C, D) \
   if(C > A) \
   { \
-    printf((__constant char *)"EEEEEK, step %d nn.dX is too big: %x, tid=%u\n", B, C, get_global_id(0)); \
+    printf((__constant char *)"warning: step %d nn.dX is too big: %x, tid=%u\n", B, C, get_global_id(0)); \
     modbasecase_debug[D]++; \
   }
 #else


### PR DESCRIPTION
mfakto should now run without errors if compiled with the `CHECKS_MODBASECASE` option.