### PR TITLE
Detect architecture in the Makefile, don't hardcode x86_64

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,8 +21,7 @@
 # Example: "make bitness=32 static=yes" to compile for 32 bits and link
 #          statically
 
-# set x86_64 (64-bit) as default
-ARCH := x86_64
+ARCH := $(shell uname -m)
 BITS := -m64
 
 # check whether to build 32-bit version

--- a/src/Makefile.macOS
+++ b/src/Makefile.macOS
@@ -26,7 +26,7 @@
 #
 # export SDKROOT=/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk
 
-ARCH = x86_64
+ARCH = $(shell uname -m)
 
 # compiler settings for C and C++ files
 CC = gcc


### PR DESCRIPTION
Users of non-x86 architectures should not feel like second class citizens anymore.

On MacOS on Apple Silicon, `uname -m` returns `arm64` (not `aarch64`), but "gcc" (actually clang) accepts `-arch arm64` just fine.