### PR TITLE
Only consider OpenCL platforms that have at least one device

### DIFF
--- a/src/sieve.c
+++ b/src/sieve.c
@@ -27,8 +27,9 @@ along with mfaktc (mfakto).  If not, see <http://www.gnu.org/licenses/>.
 #endif
 #include "compatibility.h"
 #include "gpusieve.h"
-
-// void printArray(const char * Name, const unsigned int * Data, const unsigned int len, unsigned int hex);
+#ifdef DETAILED_INFO
+  #include "output.h"
+#endif
 
 /* yeah, I like global variables :) */
 static unsigned int *sieve, *sieve_base, *primes;


### PR DESCRIPTION
Request the number of devices for the platform. If there are no devices, the platform should not be selected whether it's AMD or not.

Print the number of devices for the platform if DETAILED_INFO is enabled, even if the platform is AMD.

Fix compilation with DETAILED_INFO enabled.